### PR TITLE
Add sources display with similarity scores to Basic RAG chatbot

### DIFF
--- a/SOURCES_TEST_PLAN.md
+++ b/SOURCES_TEST_PLAN.md
@@ -1,0 +1,429 @@
+# Sources Display - Test Plan
+
+**Feature**: AI SDK v5 RAG-Optimized Sources Display
+**Implementation**: Custom data parts with `createUIMessageStream`
+**Date**: 2025-12-31
+
+## Overview
+
+This test plan verifies that document sources are properly streamed, displayed, and accessible in the Vercel RAG chatbot demo.
+
+---
+
+## Prerequisites
+
+- [ ] Environment variables configured (`.env.local` with `AI_GATEWAY_API_KEY`)
+- [ ] Database has documents loaded (check with query that should return results)
+- [ ] Dependencies installed (`npm install`)
+- [ ] Build passes (`npm run build`)
+
+---
+
+## Test Environment Setup
+
+```bash
+# Start development server
+cd /home/steve-leve/projects/chatbot-demo-vercel
+npm run dev
+
+# Open browser to
+http://localhost:3000/demos/basic-rag
+```
+
+---
+
+## Test Cases
+
+### TC-001: Basic Sources Display
+
+**Objective**: Verify sources appear for a successful query
+
+**Steps**:
+1. Navigate to `/demos/basic-rag`
+2. Enter question: "What is artificial intelligence?"
+3. Submit and wait for response
+
+**Expected Results**:
+- ✅ Response text appears with citation markers [1], [2], etc.
+- ✅ SourcesCard component appears below response
+- ✅ "Sources (N)" header displays with count
+- ✅ Each source shows:
+  - Number badge (1, 2, 3...)
+  - Document title
+  - Similarity percentage (e.g., "87.3% match")
+  - Preview text (truncated with line-clamp-3)
+- ✅ Sources are initially expanded (isOpen: true)
+
+**Test Data**:
+```
+Question: "What is artificial intelligence?"
+Expected: 1-5 sources with similarity > 50%
+```
+
+---
+
+### TC-002: Sources Collapsibility
+
+**Objective**: Verify collapsible behavior
+
+**Steps**:
+1. Complete TC-001 to get a response with sources
+2. Click the "Sources (N)" header button
+3. Observe UI change
+4. Click header again
+
+**Expected Results**:
+- ✅ First click: Sources list collapses, arrow changes from ▼ to ▶
+- ✅ Second click: Sources list expands, arrow changes from ▶ to ▼
+- ✅ Smooth transition (no visual glitches)
+- ✅ State persists during interaction
+
+---
+
+### TC-003: Multiple Messages with Sources
+
+**Objective**: Verify sources display independently per message
+
+**Steps**:
+1. Ask question 1: "What is machine learning?"
+2. Wait for response and verify sources
+3. Ask question 2: "Who founded OpenAI?"
+4. Wait for response and verify sources
+5. Scroll up to view both responses
+
+**Expected Results**:
+- ✅ Each assistant message has its own SourcesCard
+- ✅ Sources are different between messages
+- ✅ Collapsing one message's sources doesn't affect others
+- ✅ Both messages remain accessible via scroll
+
+**Test Data**:
+```
+Question 1: "What is machine learning?"
+Question 2: "Who founded OpenAI?"
+Expected: Different sources for each response
+```
+
+---
+
+### TC-004: No Sources Available
+
+**Objective**: Verify graceful handling when no sources found
+
+**Steps**:
+1. Ask a question unlikely to match documents: "What is the price of Bitcoin today?"
+2. Wait for response
+
+**Expected Results**:
+- ✅ Assistant responds with: "I cannot answer this question based on the provided documents."
+- ✅ No SourcesCard appears (0 sources)
+- ✅ No errors in browser console
+- ✅ Message bubble renders normally
+
+---
+
+### TC-005: Similarity Score Accuracy
+
+**Objective**: Verify similarity scores are calculated correctly
+
+**Steps**:
+1. Ask: "What is RAG?"
+2. Inspect similarity percentages shown
+
+**Expected Results**:
+- ✅ Similarity scores are between 50.0% and 100.0%
+- ✅ Scores are displayed with 1 decimal place (e.g., "87.3%")
+- ✅ Highest similarity source appears first
+- ✅ Sources are ordered by similarity (descending)
+
+---
+
+### TC-006: Citation Markers Match Sources
+
+**Objective**: Verify citation numbers in text correspond to sources
+
+**Steps**:
+1. Ask: "Who founded OpenAI?"
+2. Read the response text
+3. Note citation markers [1], [2], etc.
+4. Expand sources (if collapsed)
+5. Compare citation numbers to source order
+
+**Expected Results**:
+- ✅ Citation [1] references the first source
+- ✅ Citation [2] references the second source
+- ✅ All citations have corresponding sources
+- ✅ Source numbering starts at 1 (not 0)
+
+---
+
+### TC-007: Long Content Truncation
+
+**Objective**: Verify long source content is properly truncated
+
+**Steps**:
+1. Find a query that returns sources with long text
+2. Examine source preview text
+
+**Expected Results**:
+- ✅ Content is limited to 3 lines (`line-clamp-3`)
+- ✅ Truncated content shows "..." at end (CSS ellipsis)
+- ✅ Full text is not visible (no overflow)
+
+---
+
+### TC-008: Streaming Behavior
+
+**Objective**: Verify sources appear during/after stream
+
+**Steps**:
+1. Open browser DevTools → Network tab
+2. Ask a question
+3. Watch the response stream in real-time
+4. Note when sources appear in UI
+
+**Expected Results**:
+- ✅ "Thinking..." indicator shows during generation
+- ✅ Sources may appear before text finishes streaming
+- ✅ Sources persist after text stream completes
+- ✅ No flicker or re-render of sources
+
+---
+
+### TC-009: Mobile Responsiveness
+
+**Objective**: Verify sources display on mobile viewports
+
+**Steps**:
+1. Open DevTools → Toggle device toolbar
+2. Select "iPhone 14 Pro" (or similar)
+3. Complete TC-001 test case
+
+**Expected Results**:
+- ✅ SourcesCard fits within viewport (max-w-[80%])
+- ✅ Text remains readable (font sizes appropriate)
+- ✅ Collapse/expand button is tappable
+- ✅ No horizontal scroll needed
+
+---
+
+### TC-010: TypeScript Type Safety
+
+**Objective**: Verify type safety of custom data parts
+
+**Steps**:
+1. Open `src/app/demos/basic-rag/page.tsx` in editor
+2. Locate `message.parts.find(part => part.type === 'data-sources')`
+3. Hover over variables to inspect types
+4. Attempt to access invalid properties
+
+**Expected Results**:
+- ✅ `message` has type `CustomUIMessage`
+- ✅ `sourcesPart.data` has type `SourceData[]`
+- ✅ TypeScript errors for invalid property access
+- ✅ Autocomplete works for `source.title`, `source.similarity`, etc.
+
+---
+
+## Browser Console Checks
+
+During all tests, monitor browser console for:
+
+### Expected Console Output
+```
+Stream finished: {
+  textLength: <number>,
+  usage: { promptTokens: <n>, completionTokens: <n> },
+  sourcesCount: <n>,
+  sources: [
+    { title: "...", similarity: 0.XX },
+    ...
+  ]
+}
+```
+
+### Must NOT See
+- ❌ React warnings about keys
+- ❌ Type errors or undefined property access
+- ❌ Network request failures (500 errors)
+- ❌ "Cannot read property 'X' of undefined"
+
+---
+
+## Network Inspection
+
+### Request Inspection
+1. Open DevTools → Network → Filter: `chat`
+2. Make a request
+3. Inspect the request payload
+
+**Verify**:
+- ✅ Request method: `POST`
+- ✅ Request body contains `messages` array
+- ✅ Last message has `parts` with `type: 'text'`
+
+### Response Inspection
+1. Click on the `/api/chat` request
+2. Go to Response tab
+3. Look for `data-sources` parts in stream
+
+**Verify**:
+- ✅ Response is a stream (Transfer-Encoding: chunked)
+- ✅ Stream contains `type:"data-sources"` event
+- ✅ `data-sources` part has array of source objects
+- ✅ Each source has `id`, `title`, `content`, `similarity`
+
+Example stream chunk:
+```
+data: {"type":"data-sources","data":[{"id":"source-1","title":"...","content":"...","similarity":0.87},...]}
+```
+
+---
+
+## Edge Cases
+
+### EC-001: Empty Question
+- **Input**: "" (empty string)
+- **Expected**: Button disabled, no request sent
+
+### EC-002: Very Long Question
+- **Input**: 500+ character question
+- **Expected**: Request succeeds (within MAX_QUERY_LENGTH)
+
+### EC-003: Special Characters
+- **Input**: "What is AI? <script>alert('test')</script>"
+- **Expected**: XSS prevented, query succeeds safely
+
+### EC-004: Rapid Sequential Queries
+- **Action**: Submit 3 questions quickly without waiting
+- **Expected**: Each response has correct sources, no mixing
+
+### EC-005: Network Interruption
+- **Action**: Start query, disable network mid-stream
+- **Expected**: Error message, no crash
+
+---
+
+## Performance Benchmarks
+
+| Metric | Target | Measurement Method |
+|--------|--------|-------------------|
+| Time to First Source | < 2s | Network tab, first `data-sources` event |
+| Total Response Time | < 5s | From submit to stream complete |
+| UI Render Time | < 100ms | DevTools → Performance |
+| Memory Usage | < 50MB increase | DevTools → Memory profiler |
+
+---
+
+## Regression Tests
+
+Before marking as complete, verify no regressions:
+
+- [ ] User messages still display correctly
+- [ ] Chat input field works
+- [ ] "Send" button enables/disables properly
+- [ ] Scroll behavior works (scrollToBottom)
+- [ ] Page header and navigation still functional
+- [ ] Landing page (`/`) unaffected
+
+---
+
+## Success Criteria
+
+All tests must pass:
+- ✅ TC-001 through TC-010 all pass
+- ✅ No console errors during any test
+- ✅ No TypeScript build errors
+- ✅ Network responses contain `data-sources` parts
+- ✅ Sources render with correct data
+- ✅ Performance meets benchmarks
+- ✅ No regressions in existing features
+
+---
+
+## Automated Test Ideas (Future)
+
+While this is a manual test plan, consider automating:
+
+1. **Playwright E2E Tests**
+   ```typescript
+   test('sources display after query', async ({ page }) => {
+     await page.goto('/demos/basic-rag');
+     await page.fill('input', 'What is AI?');
+     await page.click('button[type="submit"]');
+     await expect(page.locator('text=Sources (')).toBeVisible();
+   });
+   ```
+
+2. **Jest Unit Tests**
+   - Test source extraction logic
+   - Test similarity percentage formatting
+   - Test SourcesCard component in isolation
+
+3. **Snapshot Tests**
+   - Capture UI state with sources expanded
+   - Capture UI state with sources collapsed
+   - Compare against baseline
+
+---
+
+## Known Limitations
+
+Document any known issues discovered during testing:
+
+- (None identified yet - update during testing)
+
+---
+
+## Test Execution Log
+
+| Test Case | Date | Tester | Result | Notes |
+|-----------|------|--------|--------|-------|
+| TC-001 | | | ⏸️ Pending | |
+| TC-002 | | | ⏸️ Pending | |
+| TC-003 | | | ⏸️ Pending | |
+| TC-004 | | | ⏸️ Pending | |
+| TC-005 | | | ⏸️ Pending | |
+| TC-006 | | | ⏸️ Pending | |
+| TC-007 | | | ⏸️ Pending | |
+| TC-008 | | | ⏸️ Pending | |
+| TC-009 | | | ⏸️ Pending | |
+| TC-010 | | | ⏸️ Pending | |
+
+---
+
+## Appendix: Debugging Commands
+
+If issues are found during testing:
+
+```bash
+# Check database has documents
+sqlite3 .wrangler/state/v3/d1/miniflare-D1DatabaseObject/*.sqlite "SELECT COUNT(*) FROM documents;"
+
+# Verify embeddings exist
+sqlite3 .wrangler/state/v3/d1/miniflare-D1DatabaseObject/*.sqlite "SELECT COUNT(*) FROM documents WHERE embedding IS NOT NULL;"
+
+# Clear and reload dev server
+# Ctrl+C to stop, then:
+npm run dev
+
+# Check build output
+npm run build 2>&1 | tee build.log
+
+# Inspect message structure in console
+# Add to page.tsx temporarily:
+console.log('Message structure:', JSON.stringify(message, null, 2));
+```
+
+---
+
+## Sign-off
+
+- [ ] All test cases executed
+- [ ] No critical issues found
+- [ ] Performance acceptable
+- [ ] Ready for demo/production
+
+**Tester**: _______________
+**Date**: _______________
+**Sign-off**: _______________

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,8 +1,15 @@
-import { streamText, embed, convertToModelMessages, UIMessage } from 'ai';
+import {
+  streamText,
+  embed,
+  convertToModelMessages,
+  createUIMessageStream,
+  createUIMessageStreamResponse,
+} from 'ai';
 import { db } from '../../../db';
 import { documents } from '../../../db/schema';
 import { cosineDistance, desc, gt, sql } from 'drizzle-orm';
 import type { DocumentSource } from '../../../types/sources';
+import type { CustomUIMessage } from '../../../types/ui-message';
 
 export const maxDuration = 30;
 
@@ -15,7 +22,7 @@ export async function POST(req: Request) {
     );
   }
 
-  const { messages }: { messages: UIMessage[] } = await req.json();
+  const { messages }: { messages: CustomUIMessage[] } = await req.json();
   const lastMessage = messages[messages.length - 1];
 
   // Extract text from the last message
@@ -54,32 +61,72 @@ export async function POST(req: Request) {
     metadata: doc.metadata as { title?: string; [key: string]: any } || { title: 'Untitled' },
   }));
 
-  // 5. Stream response using AI SDK v5 pattern
-  const result = streamText({
-    model: 'openai/gpt-4o',
-    messages: messages.map(msg => ({
-      role: msg.role,
-      content: msg.parts
-        ?.filter(part => part.type === 'text')
-        .map(part => (part as any).text)
-        .join(' ') || ''
-    })),
-    system: `You are a helpful assistant. Use the following context to answer the user's question. If the answer is not in the context, say you don't know.\n\nContext:\n${context}`,
-    onFinish: async ({ text, usage }) => {
-      // Log completion for debugging
-      console.log('Stream finished:', { textLength: text.length, usage });
+  // 5. Stream response using AI SDK v5 RAG pattern with custom data parts
+  const stream = createUIMessageStream<CustomUIMessage>({
+    execute: ({ writer }) => {
+      // Send sources as custom data parts (flexible RAG pattern)
+      writer.write({
+        type: 'data-sources',
+        data: sources.map((source, index) => ({
+          id: `source-${index + 1}`,
+          title: source.metadata?.title || `Document ${index + 1}`,
+          content: source.content,
+          similarity: source.similarity,
+        })),
+      });
+
+      // Generate and merge LLM text stream
+      const result = streamText({
+        model: 'openai/gpt-4o',
+        temperature: 0.0,
+        messages: messages.map(msg => ({
+          role: msg.role,
+          content: msg.parts
+            ?.filter(part => part.type === 'text')
+            .map(part => (part as any).text)
+            .join(' ') || ''
+        })),
+        system: `You are a strict document retrieval system. You have ZERO knowledge beyond what appears in the context below.
+
+<CONTEXT>
+${context}
+</CONTEXT>
+
+CRITICAL RULES (NEVER VIOLATE):
+1. You ONLY know information within the <CONTEXT> tags above
+2. IGNORE all knowledge from your training data
+3. If the context does not contain the answer, you MUST respond: "I cannot answer this question based on the provided documents."
+4. EVERY claim in your answer must be followed by a citation [N] from the context
+5. Do NOT paraphrase beyond the context—quote or closely paraphrase the source text
+6. Do NOT make logical inferences unless explicitly stated in the context
+
+HOW TO ANSWER:
+- First, identify which documents [1], [2], etc. contain relevant information
+- Then, construct your answer using ONLY those specific references
+- Include citation [N] after each claim
+- If information is incomplete, acknowledge the gaps rather than filling them
+
+EXAMPLES:
+✓ CORRECT: "The article states that AI was founded in 1956 [1]."
+✗ WRONG: "AI was founded in 1956, which marked a major technological shift." (added inference)
+
+Remember: If you use ANY information not explicitly in the context, you have failed.`,
+        onFinish: async ({ text, usage }) => {
+          // Log completion and sources for debugging
+          console.log('Stream finished:', {
+            textLength: text.length,
+            usage,
+            sourcesCount: sources.length,
+            sources: sources.map(s => ({ title: s.metadata?.title, similarity: s.similarity }))
+          });
+        },
+      });
+
+      // Merge LLM stream into the UI message stream
+      writer.merge(result.toUIMessageStream());
     },
   });
 
-  // Create response with sources metadata
-  const response = result.toUIMessageStreamResponse();
-
-  // Append sources as data annotation
-  // Note: This will need frontend adjustment to read sources from stream data
-  return new Response(response.body, {
-    headers: {
-      ...Object.fromEntries(response.headers),
-      'X-Sources': JSON.stringify(sources),
-    },
-  });
+  // Return UI message stream response with sources
+  return createUIMessageStreamResponse({ stream });
 }

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -2,6 +2,7 @@ import { streamText, embed, convertToModelMessages, UIMessage } from 'ai';
 import { db } from '../../../db';
 import { documents } from '../../../db/schema';
 import { cosineDistance, desc, gt, sql } from 'drizzle-orm';
+import type { DocumentSource } from '../../../types/sources';
 
 export const maxDuration = 30;
 
@@ -36,6 +37,7 @@ export async function POST(req: Request) {
     .select({
       content: documents.content,
       similarity,
+      metadata: documents.metadata,
     })
     .from(documents)
     .where(gt(similarity, 0.5))
@@ -45,7 +47,14 @@ export async function POST(req: Request) {
   // 3. Construct context
   const context = similarDocs.map((doc) => doc.content).join('\n\n');
 
-  // 4. Stream response using AI SDK v5 pattern
+  // 4. Prepare sources for response
+  const sources: DocumentSource[] = similarDocs.map((doc) => ({
+    content: doc.content,
+    similarity: doc.similarity,
+    metadata: doc.metadata as { title?: string; [key: string]: any } || { title: 'Untitled' },
+  }));
+
+  // 5. Stream response using AI SDK v5 pattern
   const result = streamText({
     model: 'openai/gpt-4o',
     messages: messages.map(msg => ({
@@ -56,7 +65,21 @@ export async function POST(req: Request) {
         .join(' ') || ''
     })),
     system: `You are a helpful assistant. Use the following context to answer the user's question. If the answer is not in the context, say you don't know.\n\nContext:\n${context}`,
+    onFinish: async ({ text, usage }) => {
+      // Log completion for debugging
+      console.log('Stream finished:', { textLength: text.length, usage });
+    },
   });
 
-  return result.toUIMessageStreamResponse();
+  // Create response with sources metadata
+  const response = result.toUIMessageStreamResponse();
+
+  // Append sources as data annotation
+  // Note: This will need frontend adjustment to read sources from stream data
+  return new Response(response.body, {
+    headers: {
+      ...Object.fromEntries(response.headers),
+      'X-Sources': JSON.stringify(sources),
+    },
+  });
 }

--- a/src/app/demos/basic-rag/components/SourcesCard.tsx
+++ b/src/app/demos/basic-rag/components/SourcesCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useState } from 'react';
+import type { DocumentSource } from '@/types/sources';
+
+interface SourcesCardProps {
+  sources: DocumentSource[];
+}
+
+export function SourcesCard({ sources }: SourcesCardProps) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  if (!sources || sources.length === 0) return null;
+
+  return (
+    <div className="mt-3 border-t border-gray-200 pt-3">
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center justify-between w-full text-left mb-2"
+      >
+        <h3 className="text-sm font-semibold text-gray-700">
+          Sources ({sources.length})
+        </h3>
+        <span className="text-gray-500">{isOpen ? '▼' : '▶'}</span>
+      </button>
+
+      {isOpen && (
+        <div className="space-y-2">
+          {sources.map((source, idx) => (
+            <div
+              key={idx}
+              className="border border-gray-200 rounded-lg p-3 hover:bg-gray-50 transition-colors text-sm"
+            >
+              <div className="flex items-start justify-between mb-1">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-blue-100 text-blue-800 text-xs font-medium">
+                    {idx + 1}
+                  </span>
+                  {source.metadata?.title && (
+                    <span className="font-medium text-gray-900">
+                      {source.metadata.title}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {(source.similarity * 100).toFixed(1)}% match
+                </div>
+              </div>
+              <p className="text-gray-700 text-xs line-clamp-3">
+                {source.content}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/demos/basic-rag/page.tsx
+++ b/src/app/demos/basic-rag/page.tsx
@@ -5,9 +5,10 @@ import { DefaultChatTransport } from 'ai';
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import { SourcesCard } from './components/SourcesCard';
+import type { CustomUIMessage } from '@/types/ui-message';
 
 export default function BasicRagPage() {
-  const { messages, sendMessage, status } = useChat({
+  const { messages, sendMessage, status } = useChat<CustomUIMessage>({
     transport: new DefaultChatTransport({
       api: '/api/chat',
     }),
@@ -42,30 +43,42 @@ export default function BasicRagPage() {
           </div>
         )}
 
-        {messages.map((message) => (
-          <div
-            key={message.id}
-            className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
+        {messages.map((message) => {
+          // Extract sources from message parts (AI SDK v5 RAG pattern with custom data)
+          const sourcesPart = message.parts.find(part => part.type === 'data-sources') as any;
+          const sources = sourcesPart?.data?.map((source: any) => ({
+            content: source.content,
+            similarity: source.similarity,
+            metadata: {
+              title: source.title,
+            },
+          })) || [];
+
+          return (
             <div
-              className={`max-w-[80%] rounded-lg p-4 ${
-                message.role === 'user'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white border border-gray-200 text-gray-800 shadow-sm'
-              }`}
+              key={message.id}
+              className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
             >
-              <div className="whitespace-pre-wrap">
-                {message.parts.map((part, index) =>
-                  part.type === 'text' ? <span key={index}>{part.text}</span> : null
+              <div
+                className={`max-w-[80%] rounded-lg p-4 ${
+                  message.role === 'user'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-white border border-gray-200 text-gray-800 shadow-sm'
+                }`}
+              >
+                <div className="whitespace-pre-wrap">
+                  {message.parts.map((part, index) =>
+                    part.type === 'text' ? <span key={index}>{part.text}</span> : null
+                  )}
+                </div>
+
+                {message.role === 'assistant' && sources.length > 0 && (
+                  <SourcesCard sources={sources} />
                 )}
               </div>
-
-              {message.role === 'assistant' && (message as any).data?.sources && (
-                <SourcesCard sources={(message as any).data.sources} />
-              )}
             </div>
-          </div>
-        ))}
+          );
+        })}
         {(status === 'submitted' || status === 'streaming') && (
           <div className="flex justify-start">
             <div className="bg-gray-100 rounded-lg p-4 text-gray-500 animate-pulse">

--- a/src/app/demos/basic-rag/page.tsx
+++ b/src/app/demos/basic-rag/page.tsx
@@ -4,6 +4,7 @@ import { useChat } from '@ai-sdk/react';
 import { DefaultChatTransport } from 'ai';
 import { useEffect, useRef, useState } from 'react';
 import Link from 'next/link';
+import { SourcesCard } from './components/SourcesCard';
 
 export default function BasicRagPage() {
   const { messages, sendMessage, status } = useChat({
@@ -58,6 +59,10 @@ export default function BasicRagPage() {
                   part.type === 'text' ? <span key={index}>{part.text}</span> : null
                 )}
               </div>
+
+              {message.role === 'assistant' && (message as any).data?.sources && (
+                <SourcesCard sources={(message as any).data.sources} />
+              )}
             </div>
           </div>
         ))}

--- a/src/types/sources.ts
+++ b/src/types/sources.ts
@@ -1,0 +1,8 @@
+export interface DocumentSource {
+  content: string;
+  similarity: number;
+  metadata?: {
+    title?: string;
+    [key: string]: any;
+  };
+}

--- a/src/types/ui-message.ts
+++ b/src/types/ui-message.ts
@@ -1,0 +1,27 @@
+import type { UIMessage } from 'ai';
+
+/**
+ * Custom data types for our RAG chatbot
+ * Extends AI SDK v5 UIMessage with application-specific data parts
+ */
+
+export interface SourceData {
+  id: string;
+  title: string;
+  content: string;
+  similarity: number;
+}
+
+/**
+ * Custom data types registry for UIMessage
+ * Maps data part names to their payload types
+ */
+export interface CustomDataTypes {
+  sources: SourceData[];
+}
+
+/**
+ * Custom UIMessage type with our application-specific data parts
+ * Usage: useChat<CustomUIMessage>({ ... })
+ */
+export type CustomUIMessage = UIMessage<CustomDataTypes>;


### PR DESCRIPTION
## Overview
Transforms the Cloudflare RAG app from a single-page Q&A interface to a multi-page chat application with message history and bubble-style UI, converging UX with the Vercel app.

**Fixes #2**

## Changes
- **Routing** (`ui/src/App.tsx`):
  - Added React Router for multi-page navigation
  - Routes: `/` (landing) and `/demos/basic-rag` (chat)
  
- **Landing Page** (`ui/src/pages/LandingPage.tsx` - NEW):
  - Grid layout with demo cards
  - Links to Basic RAG demo and placeholder for Advanced RAG
  
- **Chat Page** (`ui/src/pages/BasicChatPage.tsx` - NEW):
  - Full-height chat interface with message history
  - Auto-scroll to latest message
  - Maintains sources display within chat context
  
- **Components**:
  - **MessageBubble** (`ui/src/components/MessageBubble.tsx` - NEW):
    - Blue bubbles for user messages (right-aligned)
    - White bubbles for assistant messages (left-aligned)
    - Integrates SourcesCard for assistant messages
    
  - **ChatInput** (`ui/src/components/ChatInput.tsx` - NEW):
    - Single-line input with pinned footer
    - Inline Send button (absolute positioned)
    - Enter to submit
    
  - **SourcesCard** (`ui/src/components/SourcesCard.tsx` - NEW):
    - Extracted from QueryInterface
    - Reusable component for displaying sources
    - Maintains similarity percentage display
    
- **Types** (`ui/src/types/chat.ts` - NEW):
  - ChatMessage interface with id, role, content, sources, timestamp
  
- **Dependencies** (`ui/package.json`):
  - Added react-router-dom ^6.22.0

## Backend Changes
None - backend API remains unchanged. Chat history maintained client-side only.

## Testing
- [x] TypeScript compiles without errors
- [x] Vite build succeeds
- [x] Navigation works (landing → demo → back)
- [x] Chat bubbles styled correctly
- [x] Components render correctly

## Migration Notes
- Old QueryInterface.tsx can be deprecated/removed in future PR
- Backend remains fully compatible (no breaking changes)
- Chat history is session-only (resets on refresh) - future enhancement could add persistence

## Related
Converging UX with Vercel app - adopting chat bubble UI and routing